### PR TITLE
get_default_params as general function to retrieve params for sorters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     - libcanberra-gtk-module
 install:
 - pip install https://github.com/SpikeInterface/spikeextractors/archive/master.zip
+- pip install spikesorters==0.1.0
 - pip install .
 - pip install pytest==4.3
 - pip install numpy==1.16.2 scipy h5py six cython tqdm click

--- a/spikesorters/sorterlist.py
+++ b/spikesorters/sorterlist.py
@@ -57,7 +57,34 @@ def run_sorter(sorter_name_or_class, recording, output_folder=None, delete_outpu
 
 
 def available_sorters():
+    '''
+    Lists available sorters.
+    '''
     return sorted(list(sorter_dict.keys()))
+
+def get_default_params(sorter_name_or_class):
+    '''
+    Returns default parameters for the specified sorter.
+
+    Parameters
+    ----------
+    sorter_name_or_class: str or SorterClass
+        The sorter to retrieve default parameters from
+
+    Returns
+    -------
+    default_params: dict
+        Dictionary with default params for the specified sorter
+
+    '''
+    if isinstance(sorter_name_or_class, str):
+        SorterClass = sorter_dict[sorter_name_or_class]
+    elif sorter_name_or_class in sorter_full_list:
+        SorterClass = sorter_name_or_class
+    else:
+        raise(ValueError('Unknown sorter'))
+
+    return SorterClass.default_params()
 
 
 # make aliases


### PR DESCRIPTION
Added a `get_default_params()` function in the sorterlist.

Now one can retrieve default params as:

`sorters.get_default_params('klusta')`