### PR TITLE
Gui params added to all sorters

### DIFF
--- a/spikesorters/basesorter.py
+++ b/spikesorters/basesorter.py
@@ -34,7 +34,7 @@ class BaseSorter:
     _default_params = {}
     _gui_params = [
         {'name': 'output_folder', 'type': 'str', 'value':None, 'default':None,  'title': "Sorting output folder path"},
-        {'name': 'parallel', 'type': 'bool', 'value':False, 'default':False,  'title': "If True, then parallelize"},
+        {'name': 'grouping_property', 'type': 'str', 'value':None, 'default':None,  'title': "Will sort the recording by the given property"},
     ]
     installation_mesg = ""  # error message when not installed
 

--- a/spikesorters/herdingspikes/herdingspikes.py
+++ b/spikesorters/herdingspikes/herdingspikes.py
@@ -39,7 +39,7 @@ class HerdingspikesSorter(BaseSorter):
             'title': "Cutout size before peak (ms)"},
         {'name': 'right_cutout_time', 'type': 'float', 'value': 1.0, 'default': 1.0,
             'title': "Cutout size after peak (ms)"},
-        {'name': 'detection_threshold', 'type': 'int', 'value': 18, 'default': 18,
+        {'name': 'detection_threshold', 'type': 'float', 'value': 18.0, 'default': 18.0,
             'title': "Detection threshold"},
         {'name': 'probe_masked_channels', 'type': 'list', 'value': [], 'default': [],
             'title': "Masked channels"},

--- a/spikesorters/ironclust/ironclust.py
+++ b/spikesorters/ironclust/ironclust.py
@@ -1,6 +1,8 @@
+import copy
 import os
 from pathlib import Path
 from typing import Union
+import copy
 
 import spikeextractors as se
 
@@ -52,13 +54,46 @@ class IronClustSorter(BaseSorter):
         min_count=30,  # Minimum cluster size
         fGpu=True,  # Use GPU if available
         fft_thresh=8,  # FFT-based noise peak threshold
-        fft_thresh_low=0,  # FFT-based noise peak lower threshold (set to 0 to disable dual thresholding scheme
+        fft_thresh_low=0,  # FFT-based noise peak lower threshold (set to 0 to disable dual thresholding scheme)
         nSites_whiten=32,  # Number of adjacent channels to whiten
         feature_type='gpca',  # gpca, pca, vpp, vmin, vminmax, cov, energy, xcov
         delta_cut=1,  # Cluster detection threshold (delta-cutoff)
         post_merge_mode=1,  # post merge mode
         sort_mode=1  # sort mode
     )
+
+    _extra_gui_params = [
+        {'name': 'detect_sign', 'type': 'int', 'value': -1, 'default': -1,
+         'title': "Use -1, 0, or 1, depending on the sign of the spikes in the recording"},
+        {'name': 'adjacency_radius', 'type': 'float', 'value': 50.0, 'default': 50.0, 'title': "Use -1 to include all channels in every neighborhood"},
+        {'name': 'adjacency_radius_out', 'type': 'float', 'value': 75.0, 'default': 75.0, 'title': "Use -1 to include all channels in every neighborhood"},
+        {'name': 'detect_threshold', 'type': 'float', 'value': 4.5, 'default': 4.5, 'title': "Threshold for detection"},
+        {'name': 'freq_min', 'type': 'float', 'value': 300.0, 'default': 300.0, 'title': "Low-pass frequency"},
+        {'name': 'freq_max', 'type': 'float', 'value': 6000.0, 'default': 6000.0, 'title': "High-pass frequency"},
+        {'name': 'prm_template_name', 'type': 'str', 'value': '', 'default': '', 'title': ".prm template file name"},
+        {'name': 'merge_thresh', 'type': 'float', 'value': 0.985, 'default': 0.985, 'title': "Threshold for merging"},
+        {'name': 'pc_per_chan', 'type': 'int', 'value': 2, 'default': 2, 'title': "Number of principal components per channel"},
+        {'name': 'whiten', 'type': 'bool', 'value': True, 'default': True, 'title': "Whitens the recording if True"},
+        {'name': 'filter_type', 'type': 'str', 'value': 'bandpass', 'default': 'bandpass', 'title': "none, bandpass, wiener, fftdiff, ndiff"},
+        {'name': 'filter_detect_type', 'type': 'str', 'value': 'none', 'default': 'none', 'title': "none, bandpass, wiener, fftdiff, ndiff"},
+        {'name': 'common_ref_type', 'type': 'str', 'value': 'none', 'default': 'none', 'title': "none, bandpass, wiener, fftdiff, ndiff"},
+        {'name': 'batch_sec_drift', 'type': 'int', 'value': 300, 'default': 300, 'title': "batch duration in seconds. clustering time duration"},
+        {'name': 'step_sec_drift', 'type': 'int', 'value': 20, 'default': 20, 'title': "compute anatomical similarity every n sec"},
+        {'name': 'knn', 'type': 'int', 'value': 30, 'default': 30, 'title': "K nearest neighbors"},
+        {'name': 'min_count', 'type': 'int', 'value': 30, 'default': 30, 'title': "Minimum cluster size"},
+        {'name': 'fGpu', 'type': 'bool', 'value': True, 'default': True, 'title': "Use GPU if available"},
+        {'name': 'fft_thresh', 'type': 'float', 'value': 8.0, 'default': 8.0, 'title': "FFT-based noise peak threshold"},
+        {'name': 'fft_thresh_low', 'type': 'float', 'value': 0.0, 'default': 0.0, 'title': "FFT-based noise peak lower threshold (set to 0 to disable dual thresholding scheme)"},
+        {'name': 'nSites_whiten', 'type': 'int', 'value': 32, 'default': 32, 'title': "Number of adjacent channels to whiten"},
+        {'name': 'feature_type', 'type': 'str', 'value': 'gpca', 'default': 'gpca', 'title': "gpca, pca, vpp, vmin, vminmax, cov, energy, xcov"},
+        {'name': 'delta_cut', 'type': 'int', 'value': 1, 'default': 1, 'title': "Cluster detection threshold (delta-cutoff)"},
+        {'name': 'post_merge_mode', 'type': 'int', 'value': 1, 'default': 1, 'title': "post merge mode"},
+        {'name': 'sort_mode', 'type': 'int', 'value': 1, 'default': 1, 'title': "sort mode"},
+    ]
+
+    _gui_params = copy.deepcopy(BaseSorter._gui_params)
+    for param in _extra_gui_params:
+        _gui_params.append(param)
 
     installation_mesg = """\nTo use IronClust run:\n
         >>> git clone https://github.com/jamesjun/ironclust

--- a/spikesorters/kilosort/kilosort.py
+++ b/spikesorters/kilosort/kilosort.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 import os
 import sys
@@ -41,6 +42,19 @@ class KilosortSorter(BaseSorter):
         'freq_min': 300,
         'freq_max': 6000
     }
+
+    _extra_gui_params = [
+        {'name': 'detect_threshold', 'type': 'float', 'value': 6.0, 'default': 6.0, 'title': "Relative detection threshold"},
+        {'name': 'car', 'type': 'bool', 'value': True, 'default': True, 'title': "car"},
+        {'name': 'useGPU', 'type': 'bool', 'value': True, 'default': True, 'title': "If True, will use GPU"},
+        {'name': 'electrode_dimensions', 'type': 'list', 'value': None, 'default': None, 'title': "Electrode dimensions of probe"},
+        {'name': 'freq_min', 'type': 'float', 'value': 300.0, 'default': 300.0, 'title': "Low-pass frequency"},
+        {'name': 'freq_max', 'type': 'float', 'value': 6000.0, 'default': 6000.0, 'title': "High-pass frequency"},
+    ]
+
+    _gui_params = copy.deepcopy(BaseSorter._gui_params)
+    for param in _extra_gui_params:
+        _gui_params.append(param)
 
     installation_mesg = """\nTo use Kilosort run:\n
         >>> git clone https://github.com/cortex-lab/KiloSort

--- a/spikesorters/kilosort2/kilosort2.py
+++ b/spikesorters/kilosort2/kilosort2.py
@@ -4,6 +4,7 @@ import sys
 import numpy as np
 from typing import Union
 import shutil
+import copy
 
 import spikeextractors as se
 from ..basesorter import BaseSorter
@@ -42,6 +43,20 @@ class Kilosort2Sorter(BaseSorter):
         'sigmaMask': 30,
         'nPCs': 3
     }
+
+    _extra_gui_params = [
+        {'name': 'detect_threshold', 'type': 'float', 'value': 5.0, 'default': 5.0, 'title': "Relative detection threshold"},
+        {'name': 'car', 'type': 'bool', 'value': True, 'default': True, 'title': "car"},
+        {'name': 'minFR', 'type': 'float', 'value': 0.1, 'default': 0.1, 'title': "minFR"},
+        {'name': 'electrode_dimensions', 'type': 'list', 'value': None, 'default': None, 'title': "Electrode dimensions of probe"},
+        {'name': 'freq_min', 'type': 'float', 'value': 150.0, 'default': 150.0, 'title': "Low-pass frequency"},
+        {'name': 'sigmaMask', 'type': 'int', 'value': 30, 'default': 30, 'title': "Sigma mask"},
+        {'name': 'nPCs', 'type': 'int', 'value': 3, 'default': 3, 'title': "Number of principal components"},
+    ]
+
+    _gui_params = copy.deepcopy(BaseSorter._gui_params)
+    for param in _extra_gui_params:
+        _gui_params.append(param)
 
     installation_mesg = """\nTo use Kilosort2 run:\n
         >>> git clone https://github.com/MouseLand/Kilosort2

--- a/spikesorters/klusta/klusta.py
+++ b/spikesorters/klusta/klusta.py
@@ -49,10 +49,10 @@ class KlustaSorter(BaseSorter):
     }
 
     _extra_gui_params = [
-        {'name': 'adjacency_radius', 'type': 'float', 'value': None, 'default': None, 'title': "Adjacency radius"},
-        {'name': 'threshold_strong_std_factor', 'type': 'int', 'value': 5, 'default': 5,
+        {'name': 'adjacency_radius', 'type': 'float', 'value': None, 'default': None, 'title': "Adjacency radius (microns)"},
+        {'name': 'threshold_strong_std_factor', 'type': 'float', 'value': 5.0, 'default': 5.0,
          'title': "Threshold strong std factor"},
-        {'name': 'threshold_weak_std_factor', 'type': 'int', 'value': 2, 'default': 2,
+        {'name': 'threshold_weak_std_factor', 'type': 'float', 'value': 2.0, 'default': 2.0,
          'title': "Threshold weak std factor"},
         {'name': 'detect_sign', 'type': 'int', 'value': -1, 'default': -1,
          'title': "Use -1, 0, or 1, depending on the sign of the spikes in the recording"},

--- a/spikesorters/mountainsort4/mountainsort4.py
+++ b/spikesorters/mountainsort4/mountainsort4.py
@@ -38,7 +38,7 @@ class Mountainsort4Sorter(BaseSorter):
     _extra_gui_params = [
         {'name': 'detect_sign', 'type': 'int', 'value': -1, 'default': -1,
          'title': "Use -1, 0, or 1, depending on the sign of the spikes in the recording"},
-        {'name': 'adjacency_radius', 'type': 'int', 'value': -1, 'default': -1,
+        {'name': 'adjacency_radius', 'type': 'float', 'value': -1, 'default': -1,
          'title': "Use -1 to include all channels in every neighborhood"},
         {'name': 'freq_min', 'type': 'float', 'value': 300.0, 'default': 300.0, 'title': "Low-pass frequency"},
         {'name': 'freq_max', 'type': 'float', 'value': 6000.0, 'default': 6000.0, 'title': "High-pass frequency"},
@@ -48,7 +48,7 @@ class Mountainsort4Sorter(BaseSorter):
         {'name': 'curation', 'type': 'bool', 'value': False, 'default': False, 'title': "Curates the output if True"},
         {'name': 'num_workers', 'type': 'int', 'value': None, 'default': None, 'title': "Number of parallel workers"},
         {'name': 'clip_size', 'type': 'int', 'value': 50, 'default': 50, 'title': "Clip size"},
-        {'name': 'detect_threshold', 'type': 'int', 'value': 3, 'default': 3, 'title': "Threshold for detection"},
+        {'name': 'detect_threshold', 'type': 'float', 'value': 3.0, 'default': 3.0, 'title': "Threshold for detection"},
         {'name': 'detect_interval', 'type': 'int', 'value': 10, 'default': 10,
          'title': "Minimum number of timepoints between events detected on the same channel"},
         {'name': 'noise_overlap_threshold', 'type': 'float', 'value': 0.15, 'default': 0.15,

--- a/spikesorters/spyking_circus/spyking_circus.py
+++ b/spikesorters/spyking_circus/spyking_circus.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 import os
 import shutil
@@ -35,6 +36,28 @@ class SpykingcircusSorter(BaseSorter):
         'whitening_max_elts': 1000,  # I believe it relates to subsampling and affects compute time
         'clustering_max_elts': 10000,  # I believe it relates to subsampling and affects compute time
         }
+
+    _extra_gui_params = [
+        {'name': 'detect_sign', 'type': 'int', 'value': -1, 'default': -1,
+         'title': "Use -1, 0, or 1, depending on the sign of the spikes in the recording"},
+        {'name': 'adjacency_radius', 'type': 'float', 'value': 200.0, 'default': 200.0,
+         'title': "Distance (in microns) of the adjacency radius"},
+        {'name': 'detect_threshold', 'type': 'float', 'value': 6.0, 'default': 6.0, 'title': "Threshold for detection"},
+        {'name': 'template_width_ms', 'type': 'float', 'value': 3.0, 'default': 3.0, 'title': "Width of templates (ms)"},
+        {'name': 'filter', 'type': 'bool', 'value': True, 'default': True,
+         'title': "If True, the recording will be filtered"},
+        {'name': 'merge_spikes', 'type': 'bool', 'value': True, 'default': True,
+         'title': "If True, spikes will be merged at the end."},
+        {'name': 'auto_merge', 'type': 'float', 'value': 0.5, 'default': 0.5, 'title': "Auto-merge value"},
+        {'name': 'num_workers', 'type': 'int', 'value': None, 'default': None, 'title': "Number of parallel workers"},
+        {'name': 'electrode_dimensions', 'type': 'list', 'value': None, 'default': None, 'title': "The dimensions of the electrode"},
+        {'name': 'whitening_max_elts', 'type': 'int', 'value': 1000, 'default': 1000, 'title': "Related to subsampling"},
+        {'name': 'clustering_max_elts', 'type': 'int', 'value': 10000, 'default': 10000, 'title': "Related to subsampling"},
+    ]
+
+    _gui_params = copy.deepcopy(BaseSorter._gui_params)
+    for param in _extra_gui_params:
+        _gui_params.append(param)
 
     installation_mesg = """
         >>> pip install spyking-circus

--- a/spikesorters/tridesclous/tridesclous.py
+++ b/spikesorters/tridesclous/tridesclous.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import os
 import shutil
 import numpy as np
+import copy
 
 from ..basesorter import BaseSorter
 import spikeextractors as se
@@ -36,6 +37,24 @@ class TridesclousSorter(BaseSorter):
         'feature_method': 'auto',   #peak_max/global_pca/by_channel_pca
         'cluster_method': 'auto',  #sawchaincut/dbscan/kmeans
     }
+
+    extra_gui_params = [
+        {'name': 'lowpass_freq', 'type': 'float', 'value': 400.0, 'default': 400.0, 'title': "Low-pass frequency"},
+        {'name': 'highpass_freq', 'type': 'float', 'value': 5000.0, 'default': 5000.0, 'title': "High-pass frequency"},
+        {'name': 'peak_sign', 'type': 'str', 'value': '-', 'default': '-', 'title': "Negative or positive peak sign"},
+        {'name': 'relative_threshold', 'type': 'float', 'value': 5.0, 'default': 5.0, 'title': "Relative threshold for detection"},
+        {'name': 'peak_span_ms', 'type': 'float', 'value': 0.3, 'default': 0.3, 'title': "Time span of peaks for detected events (ms)"},
+        {'name': 'wf_left_ms', 'type': 'float', 'value': -2.0, 'default': -2.0, 'title': "Waveform length before peak (ms)"},
+        {'name': 'wf_right_ms', 'type': 'float', 'value': 3.0, 'default': 3.0, 'title': "Waveform length after peak (ms)"},
+        {'name': 'nb_max', 'type': 'int', 'value': 20000, 'default': 20000, 'title': "nb_max"},
+        {'name': 'alien_value_threshold', 'type': 'float', 'value': None, 'default': None, 'title': "Threshold for artifacts"},
+        {'name': 'feature_method', 'type': 'str', 'value': 'auto', 'default': 'auto', 'title': "Feature Extraction Method"},
+        {'name': 'cluster_method', 'type': 'str', 'value': 'auto', 'default': 'auto', 'title': "Clustering Method"},
+    ]
+
+    _gui_params = copy.deepcopy(BaseSorter._gui_params)
+    for param in _extra_gui_params:
+        _gui_params.append(param)
 
 
     installation_mesg = """

--- a/spikesorters/tridesclous/tridesclous.py
+++ b/spikesorters/tridesclous/tridesclous.py
@@ -38,7 +38,7 @@ class TridesclousSorter(BaseSorter):
         'cluster_method': 'auto',  #sawchaincut/dbscan/kmeans
     }
 
-    extra_gui_params = [
+    _extra_gui_params = [
         {'name': 'lowpass_freq', 'type': 'float', 'value': 400.0, 'default': 400.0, 'title': "Low-pass frequency"},
         {'name': 'highpass_freq', 'type': 'float', 'value': 5000.0, 'default': 5000.0, 'title': "High-pass frequency"},
         {'name': 'peak_sign', 'type': 'str', 'value': '-', 'default': '-', 'title': "Negative or positive peak sign"},


### PR DESCRIPTION
I added GUI params to all sorters based off the versions from master. I might need to update them for the new matlab sorters? Not sure.

For now, I think we keep GUI params as separate parameters, but it would be nice to integrate them with default params if possible to avoid duplication and potentialy mismatch between the GUI and spiketoolkit.