### PR TITLE
need location bool and error message

### DIFF
--- a/spikesorters/basesorter.py
+++ b/spikesorters/basesorter.py
@@ -31,6 +31,7 @@ class BaseSorter:
     sorter_name = ''  # convinience for reporting
     installed = False  # check at class level if isntalled or not
     SortingExtractor_Class = None  # convinience to get the extractor
+    requires_locations = False
     _default_params = {}
     sorter_gui_params = [
         {'name': 'output_folder', 'type': 'folder', 'value':None, 'default':None,  'title': "Sorting output folder path", 'base_param':True},
@@ -45,6 +46,9 @@ class BaseSorter:
 
         assert self.installed, """This sorter {} is not installed.
         Please install it with:  \n{} """.format(self.sorter_name, self.installation_mesg)
+        if self.requires_locations:
+            if 'location' not in recording.get_shared_channel_property_names():
+                raise RuntimeError("Channel locations are required for this spike sorter. Locations can be added to the RecordingExtractor by loading a probe file (.prb or .csv) or by setting them manually.")
 
         self.verbose = verbose
         self.grouping_property = grouping_property

--- a/spikesorters/herdingspikes/herdingspikes.py
+++ b/spikesorters/herdingspikes/herdingspikes.py
@@ -24,6 +24,7 @@ class HerdingspikesSorter(BaseSorter):
 
     sorter_name = 'herdingspikes'
     installed = HAVE_HS
+    requires_locations = True
 
     _extra_gui_params = [
         {'name': 'clustering_bandwidth', 'type': 'float', 'value': 5.0, 'default': 5.0,

--- a/spikesorters/ironclust/ironclust.py
+++ b/spikesorters/ironclust/ironclust.py
@@ -33,6 +33,7 @@ class IronClustSorter(BaseSorter):
     sorter_name: str = 'ironclust'
     ironclust_path: Union[str, None] = os.getenv('IRONCLUST_PATH', None)
     installed = check_if_installed(ironclust_path)
+    requires_locations = True
 
     _default_params = dict(
         detect_sign=-1,  # Use -1, 0, or 1, depending on the sign of the spikes in the recording

--- a/spikesorters/kilosort/kilosort.py
+++ b/spikesorters/kilosort/kilosort.py
@@ -35,6 +35,7 @@ class KilosortSorter(BaseSorter):
     sorter_name: str = 'kilosort'
     kilosort_path: Union[str, None] = os.getenv('KILOSORT_PATH', None)
     installed = check_if_installed(kilosort_path)
+    requires_locations = False
 
     _default_params = {
         'detect_threshold': 6,

--- a/spikesorters/kilosort2/kilosort2.py
+++ b/spikesorters/kilosort2/kilosort2.py
@@ -35,6 +35,7 @@ class Kilosort2Sorter(BaseSorter):
     sorter_name: str = 'kilosort2'
     kilosort2_path: Union[str, None] = os.getenv('KILOSORT2_PATH', None)
     installed = check_if_installed(kilosort2_path)
+    requires_locations = False
 
     _default_params = {
         'detect_threshold': 5,

--- a/spikesorters/klusta/klusta.py
+++ b/spikesorters/klusta/klusta.py
@@ -22,6 +22,7 @@ class KlustaSorter(BaseSorter):
 
     sorter_name = 'klusta'
     installed = HAVE_KLUSTA
+    requires_locations = False
 
     _default_params = {
         'probe_file': None,

--- a/spikesorters/mountainsort4/mountainsort4.py
+++ b/spikesorters/mountainsort4/mountainsort4.py
@@ -22,6 +22,7 @@ class Mountainsort4Sorter(BaseSorter):
 
     sorter_name = 'mountainsort4'
     installed = HAVE_MS4
+    requires_locations = False
 
     _default_params = {
         'detect_sign': -1,  # Use -1, 0, or 1, depending on the sign of the spikes in the recording

--- a/spikesorters/spyking_circus/spyking_circus.py
+++ b/spikesorters/spyking_circus/spyking_circus.py
@@ -22,6 +22,7 @@ class SpykingcircusSorter(BaseSorter):
 
     sorter_name = 'spykingcircus'
     installed = HAVE_SC
+    requires_locations = False
 
     _default_params = {
         'probe_file': None,

--- a/spikesorters/tridesclous/tridesclous.py
+++ b/spikesorters/tridesclous/tridesclous.py
@@ -26,6 +26,7 @@ class TridesclousSorter(BaseSorter):
 
     sorter_name = 'tridesclous'
     installed = HAVE_TDC
+    requires_locations = False
 
     _default_params = {
         'highpass_freq': 400.,

--- a/spikesorters/waveclus/waveclus.py
+++ b/spikesorters/waveclus/waveclus.py
@@ -32,6 +32,7 @@ class WaveClusSorter(BaseSorter):
     sorter_name: str = 'waveclus'
     waveclus_path: Union[str, None] = os.getenv('WAVECLUS_PATH', None)
     installed = check_if_installed(waveclus_path)
+    requires_locations = False
 
     _default_params = {
         'detect_threshold': 5,


### PR DESCRIPTION
All sorters that need locations has `requires_locations` set to `True`. If the recording does not have locations in these cases, the sorter will fail with an informative error message upon initialization.