### PR TITLE
Fix some crashes with SpikeExtractors

### DIFF
--- a/spikesorters/spyking_circus/spyking_circus.py
+++ b/spikesorters/spyking_circus/spyking_circus.py
@@ -98,8 +98,10 @@ class SpykingcircusSorter(BaseSorter):
         data_file = open_memmap(npy_file, shape=(n_chan, n_frames), dtype=np.float32, mode='w+')
         nb_chunks = n_frames // chunk_size
         for i in range(nb_chunks + 1):
-            data = recording.get_traces(start_frame=i*chunk_size, end_frame=(i+1)*chunk_size).astype('float32')
-            data_file[:, i*chunk_size:min((i+1)*chunk_size, n_frames)] = data
+            start_frame = i*chunk_size
+            end_frame = min((i+1)*chunk_size, n_frames)
+            data = recording.get_traces(start_frame=start_frame, end_frame=end_frame).astype('float32')
+            data_file[:, start_frame:end_frame] = data
 
         if p['detect_sign'] < 0:
             detect_sign = 'negative'


### PR DESCRIPTION
If I don't put the explicit min() for end_frame in recording.get_traces(), it can lead to crash depending on the data_file/version (tested on two different desktops)