### PR TITLE
Clean and remove grouping and location stuff at sorter class level

### DIFF
--- a/spikesorters/basesorter.py
+++ b/spikesorters/basesorter.py
@@ -89,7 +89,7 @@ class BaseSorter:
             
         # make dummy location if no location because some sorter need it
         for recording in self.recording_list:
-            print('WARNING! No channel location given. Make dummy location.')
+            print('WARNING! No channel location given. Add dummy location.')
             if 'location' not in recording.get_shared_channel_property_names():
                 channel_ids = recording.get_channel_ids()
                 locations = np.array([[0, i] for i in range(len(channel_ids))])

--- a/spikesorters/basesorter.py
+++ b/spikesorters/basesorter.py
@@ -86,7 +86,15 @@ class BaseSorter:
             self.recording_list = recording.get_sub_extractors_by_property(grouping_property)
             n_group = len(self.recording_list)
             self.output_folders = [output_folder / str(i) for i in range(n_group)]
-
+            
+        # make dummy location if no location because some sorter need it
+        for recording in self.recording_list:
+            print('WARNING! No channel location given. Make dummy location.')
+            if 'location' not in recording.get_shared_channel_property_names():
+                channel_ids = recording.get_channel_ids()
+                locations = np.array([[0, i] for i in range(len(channel_ids))])
+                recording.set_channel_locations(channel_ids, locations)
+        
         # make folders
         for output_folder in self.output_folders:
             if not output_folder.is_dir():
@@ -194,11 +202,14 @@ class BaseSorter:
     def _setup_recording(self, recording, output_folder):
         # need be iplemented in subclass
         # this setup ONE recording (or SubExtractor)
+        # this must copy (or not) the trace in the appropirate format
+        # this must take care of geometry file (ORB, CSV, ...)
         raise NotImplementedError
 
     def _run(self, recording, output_folder):
         # need be iplemented in subclass
         # this run the sorter on ONE recording (or SubExtractor)
+        # this must run or generate the command line to run the sorter for one recording
         raise NotImplementedError
 
     @staticmethod

--- a/spikesorters/kilosort/kilosort.py
+++ b/spikesorters/kilosort/kilosort.py
@@ -102,9 +102,7 @@ class KilosortSorter(BaseSorter):
 
         # save binary file
         input_file_path = output_folder / 'recording'
-        n_chan = recording.get_num_channels()
-        chunk_size = 2 ** 24 // n_chan
-        recording.write_to_binary_dat_format(input_file_path, dtype='int16', chunk_size=chunk_size)
+        recording.write_to_binary_dat_format(input_file_path, dtype='int16', chunk_mb=500)
 
         # set up kilosort config files and run kilosort on data
         with (source_dir / 'kilosort_master.m').open('r') as f:

--- a/spikesorters/kilosort2/kilosort2.py
+++ b/spikesorters/kilosort2/kilosort2.py
@@ -106,23 +106,17 @@ class Kilosort2Sorter(BaseSorter):
             raise Exception(Kilosort2Sorter.installation_mesg)
         assert isinstance(Kilosort2Sorter.kilosort2_path, str)
 
-        # prepare electrode positions
-        if self.grouping_property == 'group' and 'group' in recording.get_shared_channel_property_names():
-            groups = recording.get_channel_groups()
-        else:
-            groups = [1] * recording.get_num_channels()
-        if 'location' in recording.get_shared_channel_property_names():
-            positions = np.array(recording.get_channel_locations())
-            if positions.shape[1] != 2:
-                raise RuntimeError("3D 'location' are not supported. Set 2D locations instead")
-        else:
-            print("'location' information is not found. Using linear configuration")
-            positions = np.array(
-                [[0, i_ch] for i_ch in range(recording.get_num_channels())])
+        # prepare electrode positions for this group (only one group, the split is done in basesorter)
+        groups = [1] * recording.get_num_channels()
+        positions = np.array(recording.get_channel_locations())
+        if positions.shape[1] != 2:
+            raise RuntimeError("3D 'location' are not supported. Set 2D locations instead")
 
         # save binary file
         input_file_path = output_folder / 'recording'
-        recording.write_to_binary_dat_format(input_file_path, dtype='int16')
+        n_chan = recording.get_num_channels()
+        chunk_size = 2 ** 24 // n_chan
+        recording.write_to_binary_dat_format(input_file_path, dtype='int16', chunk_size=chunk_size)
 
         if p['car']:
             use_car = 1

--- a/spikesorters/kilosort2/kilosort2.py
+++ b/spikesorters/kilosort2/kilosort2.py
@@ -114,9 +114,7 @@ class Kilosort2Sorter(BaseSorter):
 
         # save binary file
         input_file_path = output_folder / 'recording'
-        n_chan = recording.get_num_channels()
-        chunk_size = 2 ** 24 // n_chan
-        recording.write_to_binary_dat_format(input_file_path, dtype='int16', chunk_size=chunk_size)
+        recording.write_to_binary_dat_format(input_file_path, dtype='int16', chunk_mb=500)
 
         if p['car']:
             use_car = 1

--- a/spikesorters/klusta/klusta.py
+++ b/spikesorters/klusta/klusta.py
@@ -26,7 +26,6 @@ class KlustaSorter(BaseSorter):
     requires_locations = False
 
     _default_params = {
-        'probe_file': None,
         'adjacency_radius': None,
         'threshold_strong_std_factor': 5,
         'threshold_weak_std_factor': 2,
@@ -84,11 +83,11 @@ class KlustaSorter(BaseSorter):
 
         experiment_name = output_folder / 'recording'
 
-        # save prb file:
-        if p['probe_file'] is None:
-            p['probe_file'] = output_folder / 'probe.prb'
-            recording.save_to_probe_file(p['probe_file'], grouping_property=self.grouping_property,
-                                         radius=p['adjacency_radius'])
+        # save prb file 
+        # note: only one group here, the split is done in basesorter
+        probe_file = output_folder / 'probe.prb'
+        recording.save_to_probe_file(probe_file, grouping_property=None,
+                                     radius=p['adjacency_radius'])
 
         # source file
         if isinstance(recording, se.BinDatRecordingExtractor) and recording._time_axis == 0 and \
@@ -117,7 +116,7 @@ class KlustaSorter(BaseSorter):
 
         # Note: should use format with dict approach here
         klusta_config = ''.join(klusta_config).format(experiment_name,
-                                                      p['probe_file'], raw_filename,
+                                                      probe_file, raw_filename,
                                                       float(recording.get_sampling_frequency()),
                                                       recording.get_num_channels(), "'{}'".format(dtype),
                                                       p['threshold_strong_std_factor'], p['threshold_weak_std_factor'],

--- a/spikesorters/klusta/klusta.py
+++ b/spikesorters/klusta/klusta.py
@@ -98,10 +98,8 @@ class KlustaSorter(BaseSorter):
         else:
             # save binary file (chunk by hcunk) into a new file
             raw_filename = output_folder / 'recording.dat'
-            n_chan = recording.get_num_channels()
-            chunk_size = 2 ** 24 // n_chan
             dtype = 'int16'
-            recording.write_to_binary_dat_format(raw_filename, time_axis=0, dtype=dtype, chunk_size=chunk_size)
+            recording.write_to_binary_dat_format(raw_filename, time_axis=0, dtype=dtype, chunk_mb=500)
 
         if p['detect_sign'] < 0:
             detect_sign = 'negative'

--- a/spikesorters/mountainsort4/mountainsort4.py
+++ b/spikesorters/mountainsort4/mountainsort4.py
@@ -95,10 +95,7 @@ class Mountainsort4Sorter(BaseSorter):
         if p['whiten']:
             recording = whiten(recording=recording)
 
-        # Check location
-        if 'location' not in recording.get_shared_channel_property_names():
-            for i, chan in enumerate(recording.get_channel_ids()):
-                recording.set_channel_property(chan, 'location', [0, i])
+        # Check location no more needed done in basesorter
 
         sorting = ml_ms4alg.mountainsort4(
             recording=recording,

--- a/spikesorters/spyking_circus/spyking_circus.py
+++ b/spikesorters/spyking_circus/spyking_circus.py
@@ -24,7 +24,6 @@ class SpykingcircusSorter(BaseSorter):
     requires_locations = False
 
     _default_params = {
-        'probe_file': None,
         'detect_sign': -1,  # -1 - 1 - 0
         'adjacency_radius': 200,  # Channel neighborhood adjacency radius corresponding to geom file
         'detect_threshold': 6,  # Threshold for detection
@@ -79,11 +78,11 @@ class SpykingcircusSorter(BaseSorter):
         p = self.params
         source_dir = Path(__file__).parent
 
-        # save prb file:
-        if p['probe_file'] is None:
-            p['probe_file'] = output_folder / 'probe.prb'
-            recording.save_to_probe_file(p['probe_file'], grouping_property=self.grouping_property,
-                                         radius=p['adjacency_radius'])
+        # save prb file
+        # note: only one group here, the split is done in basesorter
+        probe_file = output_folder / 'probe.prb'
+        recording.save_to_probe_file(probe_file, grouping_property=None,
+                                     radius=p['adjacency_radius'])
 
         # save binary file
         file_name = 'recording'
@@ -119,7 +118,7 @@ class SpykingcircusSorter(BaseSorter):
             auto = p['auto_merge']
         else:
             auto = 0
-        circus_config = ''.join(circus_config).format(sample_rate, p['probe_file'], p['template_width_ms'],
+        circus_config = ''.join(circus_config).format(sample_rate, probe_file, p['template_width_ms'],
                     p['detect_threshold'], detect_sign, p['filter'], p['whitening_max_elts'],
                     p['clustering_max_elts'], auto)
         with (output_folder / (file_name + '.params')).open('w') as f:

--- a/spikesorters/tridesclous/tridesclous.py
+++ b/spikesorters/tridesclous/tridesclous.py
@@ -85,9 +85,10 @@ class TridesclousSorter(BaseSorter):
             shutil.rmtree(str(output_folder))
         os.makedirs(str(output_folder))
 
-        # save prb file:
+        # save prb file
+        # note: only one group here, the split is done in basesorter
         probe_file = output_folder / 'probe.prb'
-        recording.save_to_probe_file(probe_file, grouping_property=self.grouping_property)
+        recording.save_to_probe_file(probe_file, grouping_property=None)
 
         # source file
         if isinstance(recording, se.BinDatRecordingExtractor) and recording._time_axis == 0:

--- a/spikesorters/tridesclous/tridesclous.py
+++ b/spikesorters/tridesclous/tridesclous.py
@@ -102,9 +102,7 @@ class TridesclousSorter(BaseSorter):
                 print('Local copy of recording')
             # save binary file (chunk by hcunk) into a new file
             raw_filename = output_folder / 'raw_signals.raw'
-            n_chan = recording.get_num_channels()
-            chunk_size = 2 ** 24 // n_chan
-            recording.write_to_binary_dat_format(raw_filename, time_axis=0, dtype='float32', chunk_size=chunk_size)
+            recording.write_to_binary_dat_format(raw_filename, time_axis=0, dtype='float32', chunk_mb=500)
             dtype = 'float32'
             offset = 0
 


### PR DESCRIPTION
The grouping stuff and location was a bit messy at each sorter level.
Some trick were implenteded for each sorter.

Now BaseSorter take care of the splitting and so only one group is run. So no trick should be used at sorter level class level.

This PR simplify and clean this stuff.

@alejoe91 @colehurwitz  @magland could you have a look ?


