### PR TITLE
To disable the automatic filters on waveclus

### DIFF
--- a/spikesorters/waveclus/p_waveclus.m
+++ b/spikesorters/waveclus/p_waveclus.m
@@ -1,5 +1,5 @@
 function p_waveclus(vcDir_temp, vcFile_raw, vcFile_mda, sRateHz, detect_sign, feature_type, scales, detect_threshold, ...
-                    min_clus, maxtemp, template_sdnum)
+                    min_clus, maxtemp, template_sdnum,detect_order,detect_fmin,detect_fmax,sort_order,sort_fmin,sort_fmax)
     % Arguments
     % -----
     % sRateHz: sampling rate
@@ -17,6 +17,12 @@ function p_waveclus(vcDir_temp, vcFile_raw, vcFile_mda, sRateHz, detect_sign, fe
     S_par.min_clus = min_clus;
     S_par.maxtemp = maxtemp;
     S_par.template_sdnum = template_sdnum;
+	S_par.detect_fmin = detect_fmin;
+	S_par.detect_fmax = detect_fmax;
+	S_par.detect_order = detect_order;
+	S_par.sort_fmin = sort_fmin;
+	S_par.sort_fmax = sort_fmax;
+	S_par.sort_order = sort_order;
 
     [nChans, ~] = size(all_data);
     cd(vcDir_temp);

--- a/spikesorters/waveclus/waveclus.py
+++ b/spikesorters/waveclus/waveclus.py
@@ -41,6 +41,14 @@ class WaveClusSorter(BaseSorter):
         'min_clus': 20,
         'maxtemp': 0.251,
         'template_sdnum': 3,
+        'enable_detect_filter': False,
+        'enable_sort_filter': False,
+        'detect_filter_fmin': 300,
+        'detect_filter_fmax': 3000,
+        'detect_filter_order': 4,
+        'sort_filter_fmin': 300,
+        'sort_filter_fmax': 3000,
+        'sort_filter_order': 2,
     }
 
     installation_mesg = """\nTo use WaveClus run:\n
@@ -96,6 +104,15 @@ class WaveClusSorter(BaseSorter):
         else:
             detect_sign = 'both'
 
+        if p['enable_detect_filter']:
+            detect_filter_order = p['detect_filter_order']
+        else:
+            detect_filter_order = 0
+        if p['enable_sort_filter']:
+            sort_filter_order = p['sort_filter_order']
+        else:
+            sort_filter_order = 0
+
         samplerate = recording.get_sampling_frequency()
 
         num_channels = recording.get_num_channels()
@@ -118,7 +135,8 @@ class WaveClusSorter(BaseSorter):
             try
                 p_waveclus('{tmpdir}', '{dataset_dir}/raw.mda', '{tmpdir}/firings.mda', {samplerate}, ...
                 '{detect_sign}', '{feature_type}', {scales}, {detect_threshold}, {min_clus}, {maxtemp}, ...
-                 {template_sdnum});
+                 {template_sdnum},{detect_filter_order},{detect_filter_fmin},{detect_filter_fmax}, ...
+                 {sort_filter_order},{sort_filter_fmin},{sort_filter_fmax});
             catch
                 fprintf('----------------------------------------');
                 fprintf(lasterr());
@@ -129,7 +147,10 @@ class WaveClusSorter(BaseSorter):
         cmd = cmd.format(waveclus_path=WaveClusSorter.waveclus_path, utils_path=utils_path, dataset_dir=dataset_dir,
                          source_path=source_dir, samplerate=samplerate, detect_sign=detect_sign, tmpdir=tmpdir,
                          feature_type=p['feature_type'], scales=p['scales'], detect_threshold=p['detect_threshold'],
-                         min_clus=p['min_clus'], maxtemp=p['maxtemp'], template_sdnum=p['template_sdnum'])
+                         min_clus=p['min_clus'], maxtemp=p['maxtemp'], template_sdnum=p['template_sdnum'],
+                         detect_filter_order=detect_filter_order, detect_filter_fmin=p['detect_filter_fmin'],
+                         detect_filter_fmax=p['detect_filter_fmax'], sort_filter_order=sort_filter_order,
+                         sort_filter_fmin=p['sort_filter_fmin'], sort_filter_fmax=p['sort_filter_fmax'])
 
         matlab_cmd = ShellScript(cmd, script_path=str(tmpdir / 'run_waveclus.m'), keep_temp_files=True)
         matlab_cmd.write()


### PR DESCRIPTION
This commit adds parameters to enable and configure the filters inside wave_clus in the spikesorter wrapper. By default, the filters will be disabled. 