### PR TITLE
Use joblib instead of threading for parallel spike sorting

### DIFF
--- a/requirements_sorters.txt
+++ b/requirements_sorters.txt
@@ -13,8 +13,8 @@ pyqt5==5.13
 hdbscan
 tridesclous==1.6
 
-# ms4 : fail on travis
-# ml_ms4alg==0.3.2
+# ms4
+ml_ms4alg==0.3.2
 
 # herdingspikes
 herdingspikes==0.3.7

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ pkg_name = "spikesorters"
 setup(
     name=pkg_name,
     version=version,
-    author="Samuel Garcia, Cole Hurwitz, Jeremy Magland, Alessio Paolo Buccino, Matthias Hennig",
+    author="Alessio Buccino, Cole Hurwitz, Samuel Garcia, Jeremy Magland, Matthias Hennig",
     author_email="alessiop.buccino@gmail.com",
     description="Python wrappers for popular spike sorters",
     long_description=long_description,

--- a/spikesorters/basesorter.py
+++ b/spikesorters/basesorter.py
@@ -38,11 +38,12 @@ class BaseSorter:
     installed = False  # check at class level if isntalled or not
     SortingExtractor_Class = None  # convinience to get the extractor
     requires_locations = False
+    compatible_with_parallel = {'loky': True, 'multiprocessing': True, 'threading': True}
     _default_params = {}
     installation_mesg = ""  # error message when not installed
 
     def __init__(self, recording=None, output_folder=None, verbose=False,
-                 grouping_property=None, parallel=False, delete_output_folder=False):
+                 grouping_property=None, delete_output_folder=False):
 
         assert self.installed, """This sorter {} is not installed.
         Please install it with:  \n{} """.format(self.sorter_name, self.installation_mesg)
@@ -54,7 +55,6 @@ class BaseSorter:
 
         self.verbose = verbose
         self.grouping_property = grouping_property
-        self.parallel = parallel
         self.params = self.default_params()
 
         if output_folder is None:
@@ -116,7 +116,7 @@ class BaseSorter:
                 params['recording'] = recording.make_serialized_dict()
                 json.dump(_check_json(params), f, indent=4)
 
-    def run(self, raise_error=True, joblib_backend=None):
+    def run(self, raise_error=True, parallel=False, n_jobs=-1, joblib_backend='loky'):
         for i, recording in enumerate(self.recording_list):
             self._setup_recording(recording, self.output_folders[i])
 
@@ -133,17 +133,21 @@ class BaseSorter:
 
         t0 = time.perf_counter()
 
-        if self.parallel and len(self.recording_list) > 1:
+        if parallel:
+            assert self.compatible_with_parallel[joblib_backend], f"{self.sorter_name} is not compatible with " \
+                                                                  f"joblib {joblib_backend} backend"
+
+        if parallel and len(self.recording_list) > 1:
             if not np.all([recording.check_if_dumpable() for recording in self.recording_list]):
-                    self.parallel = False
-                    print("RecordingExtractor objcts are not dumpable and can't be processed in parallel")
+                parallel = False
+                print("RecordingExtractor objects are not dumpable and can't be processed in parallel")
 
         try:
-            if not self.parallel:
+            if not parallel:
                 for i, recording in enumerate(self.recording_list):
                     self._run(recording, self.output_folders[i])
             else:
-                _ = Parallel(n_jobs=len(self.recording_list), backend=joblib_backend)(
+                _ = Parallel(n_jobs=n_jobs, backend=joblib_backend)(
                     delayed(self._run)(rec.dump_to_dict(), output_folder)
                     for (rec, output_folder) in zip(self.recording_list, self.output_folders))
 

--- a/spikesorters/basesorter.py
+++ b/spikesorters/basesorter.py
@@ -139,15 +139,15 @@ class BaseSorter:
 
         if parallel and len(self.recording_list) > 1:
             if not np.all([recording.check_if_dumpable() for recording in self.recording_list]):
-                parallel = False
-                print("RecordingExtractor objects are not dumpable and can't be processed in parallel")
+                raise RuntimeError("RecordingExtractor objects are not dumpable and can't be processed in parallel. "
+                                   "Use parallel=False")
 
         try:
             if not parallel:
                 for i, recording in enumerate(self.recording_list):
                     self._run(recording, self.output_folders[i])
             else:
-                _ = Parallel(n_jobs=n_jobs, backend=joblib_backend)(
+                Parallel(n_jobs=n_jobs, backend=joblib_backend)(
                     delayed(self._run)(rec.dump_to_dict(), output_folder)
                     for (rec, output_folder) in zip(self.recording_list, self.output_folders))
 

--- a/spikesorters/hdsort/hdsort.py
+++ b/spikesorters/hdsort/hdsort.py
@@ -7,6 +7,7 @@ import copy
 import spikeextractors as se
 from ..basesorter import BaseSorter
 from ..utils.shellscript import ShellScript
+from ..sorter_tools import recover_recording
 
 
 def check_if_installed(hdsort_path: Union[str, None]):
@@ -154,6 +155,7 @@ class HDSortSorter(BaseSorter):
                 f.write(txt)
 
     def _run(self, recording, output_folder):
+        recording = recover_recording(recording)
         tmpdir = output_folder
         os.makedirs(str(tmpdir), exist_ok=True)
         samplerate = recording.get_sampling_frequency()

--- a/spikesorters/herdingspikes/herdingspikes.py
+++ b/spikesorters/herdingspikes/herdingspikes.py
@@ -5,6 +5,7 @@ import spikeextractors as se
 import spiketoolkit as st
 
 from ..basesorter import BaseSorter
+from ..sorter_tools import recover_recording
 
 try:
     import herdingspikes as hs
@@ -25,7 +26,6 @@ class HerdingspikesSorter(BaseSorter):
     sorter_name = 'herdingspikes'
     installed = HAVE_HS
     requires_locations = True
-    compatile_with_parallel_thread = False
     _default_params = None  # later
 
     installation_mesg = """
@@ -65,6 +65,7 @@ class HerdingspikesSorter(BaseSorter):
             peak_jitter=p['probe_peak_jitter'])
 
     def _run(self, recording, output_folder):
+        recording = recover_recording(recording)
         p = self.params
 
         if recording.is_filtered and p['filter']:

--- a/spikesorters/herdingspikes/herdingspikes.py
+++ b/spikesorters/herdingspikes/herdingspikes.py
@@ -27,6 +27,7 @@ class HerdingspikesSorter(BaseSorter):
     installed = HAVE_HS
     requires_locations = True
     _default_params = None  # later
+    compatible_with_parallel = {'loky': True, 'multiprocessing': True, 'threading': False}
 
     installation_mesg = """
     More information on HerdingSpikes at:

--- a/spikesorters/ironclust/ironclust.py
+++ b/spikesorters/ironclust/ironclust.py
@@ -8,6 +8,7 @@ import spikeextractors as se
 
 from ..utils.shellscript import ShellScript
 from ..basesorter import BaseSorter
+from ..sorter_tools import recover_recording
 
 
 def check_if_installed(ironclust_path: Union[str, None]):
@@ -111,6 +112,7 @@ class IronClustSorter(BaseSorter):
         se.MdaRecordingExtractor.write_recording(recording=recording, save_path=str(dataset_dir))
 
     def _run(self, recording: se.RecordingExtractor, output_folder: Path):
+        recording = recover_recording(recording)
         dataset_dir = output_folder / 'ironclust_dataset'
         source_dir = Path(__file__).parent
 

--- a/spikesorters/kilosort/kilosort.py
+++ b/spikesorters/kilosort/kilosort.py
@@ -9,7 +9,7 @@ import numpy as np
 import spikeextractors as se
 from ..basesorter import BaseSorter
 from ..utils.shellscript import ShellScript
-from ..sorter_tools import get_git_commit
+from ..sorter_tools import get_git_commit, recover_recording
 
 
 def check_if_installed(kilosort_path: Union[str, None]):
@@ -170,6 +170,7 @@ class KilosortSorter(BaseSorter):
         shutil.copy(str(source_dir.parent / 'utils' / 'constructNPYheader.m'), str(output_folder))
 
     def _run(self, recording, output_folder):
+        recording = recover_recording(recording)
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
                         cd {tmpdir}

--- a/spikesorters/kilosort2/kilosort2.py
+++ b/spikesorters/kilosort2/kilosort2.py
@@ -9,7 +9,7 @@ import json
 import spikeextractors as se
 from ..basesorter import BaseSorter
 from ..utils.shellscript import ShellScript
-from ..sorter_tools import get_git_commit
+from ..sorter_tools import get_git_commit, recover_recording
 
 
 def check_if_installed(kilosort2_path: Union[str, None]):
@@ -166,6 +166,7 @@ class Kilosort2Sorter(BaseSorter):
         shutil.copy(str(source_dir.parent / 'utils' / 'constructNPYheader.m'), str(output_folder))
 
     def _run(self, recording, output_folder):
+        recording = recover_recording(recording)
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
                         cd {tmpdir}

--- a/spikesorters/klusta/klusta.py
+++ b/spikesorters/klusta/klusta.py
@@ -6,7 +6,7 @@ import spikeextractors as se
 
 from ..basesorter import BaseSorter
 from ..utils.shellscript import ShellScript
-from ..sorter_tools import _call_command
+from ..sorter_tools import recover_recording
 
 try:
     import klusta
@@ -106,6 +106,7 @@ class KlustaSorter(BaseSorter):
             f.writelines(klusta_config)
 
     def _run(self, recording, output_folder):
+        recording = recover_recording(recording)
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
                         klusta --overwrite {klusta_config}

--- a/spikesorters/mountainsort4/mountainsort4.py
+++ b/spikesorters/mountainsort4/mountainsort4.py
@@ -5,6 +5,7 @@ import spikeextractors as se
 from spiketoolkit.preprocessing import bandpass_filter, whiten
 
 from ..basesorter import BaseSorter
+from ..sorter_tools import recover_recording
 
 try:
     import ml_ms4alg
@@ -22,7 +23,6 @@ class Mountainsort4Sorter(BaseSorter):
     sorter_name = 'mountainsort4'
     installed = HAVE_MS4
     requires_locations = False
-    compatile_with_parallel_thread = False
 
     _default_params = {
         'detect_sign': -1,  # Use -1, 0, or 1, depending on the sign of the spikes in the recording
@@ -59,7 +59,7 @@ class Mountainsort4Sorter(BaseSorter):
         pass
 
     def _run(self, recording, output_folder):
-        
+        recording = recover_recording(recording)
         # Sort
         # alias to params
         p = self.params

--- a/spikesorters/mountainsort4/mountainsort4.py
+++ b/spikesorters/mountainsort4/mountainsort4.py
@@ -23,6 +23,7 @@ class Mountainsort4Sorter(BaseSorter):
     sorter_name = 'mountainsort4'
     installed = HAVE_MS4
     requires_locations = False
+    compatible_with_parallel = {'loky': True, 'multiprocessing': False, 'threading': False}
 
     _default_params = {
         'detect_sign': -1,  # Use -1, 0, or 1, depending on the sign of the spikes in the recording

--- a/spikesorters/sorter_tools.py
+++ b/spikesorters/sorter_tools.py
@@ -4,7 +4,7 @@ Some utils function to run command.
 from subprocess import Popen, PIPE, CalledProcessError, call, check_output
 import shlex
 import sys
-
+import spikeextractors as se
 
 def _run_command_and_print_output(command):
     command_list = shlex.split(command, posix="win" not in sys.platform)
@@ -51,6 +51,7 @@ def _call_command_split(command_list):
     except CalledProcessError as e:
         raise Exception(e.output)
 
+
 def get_git_commit(git_folder, shorten=True):
     if git_folder is None:
         return None
@@ -62,4 +63,10 @@ def get_git_commit(git_folder, shorten=True):
         commit = None
     return commit
 
-    
+
+def recover_recording(rec_arg):
+    if isinstance(rec_arg, dict):
+        recording = se.load_extractor_from_dict(rec_arg)
+    else:
+        recording = rec_arg
+    return recording

--- a/spikesorters/sorter_tools.py
+++ b/spikesorters/sorter_tools.py
@@ -70,3 +70,7 @@ def recover_recording(rec_arg):
     else:
         recording = rec_arg
     return recording
+
+
+class SpikeSortingError(RuntimeError):
+    """Raised whenever spike sorting fails"""

--- a/spikesorters/sorterlist.py
+++ b/spikesorters/sorterlist.py
@@ -28,7 +28,8 @@ installed_sorter_list = [s for s in sorter_full_list if s.installed]
 
 # generic laucnher via function approach
 def run_sorter(sorter_name_or_class, recording, output_folder=None, delete_output_folder=False,
-               grouping_property=None, parallel=False, verbose=False, raise_error=True, **params):
+               grouping_property=None, parallel=False, verbose=False, raise_error=True, n_jobs=-1, joblib_backend='loky',
+               **params):
     """
     Generic function to run a sorter via function approach.
 
@@ -59,6 +60,10 @@ def run_sorter(sorter_name_or_class, recording, output_folder=None, delete_outpu
     raise_error: bool
         If True, an error is raised if spike sorting fails (default). If False, the process continues and the error is
         logged in the log file.
+    n_jobs: int
+        Number of jobs when parallel=True (default=-1)
+    joblib_backend: str
+        joblib backend when parallel=True (default='loky')
     **params: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params(sorter_name_or_class)'
 
@@ -76,9 +81,9 @@ def run_sorter(sorter_name_or_class, recording, output_folder=None, delete_outpu
         raise (ValueError('Unknown sorter'))
 
     sorter = SorterClass(recording=recording, output_folder=output_folder, grouping_property=grouping_property,
-                         parallel=parallel, verbose=verbose, delete_output_folder=delete_output_folder)
+                         verbose=verbose, delete_output_folder=delete_output_folder)
     sorter.set_params(**params)
-    sorter.run(raise_error=raise_error)
+    sorter.run(raise_error=raise_error, parallel=parallel, n_jobs=n_jobs, joblib_backend=joblib_backend)
     sortingextractor = sorter.get_result()
 
     return sortingextractor
@@ -152,7 +157,11 @@ def run_hdsort(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('hdsort')
 
@@ -185,7 +194,11 @@ def run_klusta(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('klusta')
 
@@ -218,7 +231,11 @@ def run_tridesclous(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('tridesclous')
 
@@ -251,7 +268,11 @@ def run_mountainsort4(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('mountainsort4')
 
@@ -283,8 +304,12 @@ def run_ironclust(*args, **kwargs):
         verbose: bool
             If True, output is verbose
         raise_error: bool
-            If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            If True, an error is raised if spike sorting fails (default). If False, the process continues and the error
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('ironclust')
 
@@ -317,7 +342,11 @@ def run_kilosort(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('kilosort')
 
@@ -350,7 +379,11 @@ def run_kilosort2(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('kilosort2')
 
@@ -383,7 +416,11 @@ def run_spykingcircus(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('spykingcircus')
 
@@ -416,7 +453,11 @@ def run_herdingspikes(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('herdingspikes')
 
@@ -449,7 +490,11 @@ def run_waveclus(*args, **kwargs):
             If True, output is verbose
         raise_error: bool
             If True, an error is raised if spike sorting fails (default). If False, the process continues and the error 
-            is logged in the log file.
+            is logged in the log file
+        n_jobs: int
+            Number of jobs when parallel=True (default=-1)
+        joblib_backend: str
+            joblib backend when parallel=True (default='loky')
     **kwargs: keyword args
         Spike sorter specific arguments (they can be retrieved with 'get_default_params('waveclus')
 

--- a/spikesorters/spyking_circus/spyking_circus.py
+++ b/spikesorters/spyking_circus/spyking_circus.py
@@ -7,6 +7,7 @@ import sys
 import spikeextractors as se
 from ..basesorter import BaseSorter
 from ..utils.shellscript import ShellScript
+from ..sorter_tools import recover_recording
 
 try:
     import circus
@@ -107,6 +108,7 @@ class SpykingcircusSorter(BaseSorter):
             p['num_workers'] = np.maximum(1, int(os.cpu_count()/2))
 
     def _run(self,  recording, output_folder):
+        recording = recover_recording(recording)
         if recording.is_filtered and self.params['filter']:
             print("Warning! The recording is already filtered, but Spyking-Circus filter is enabled. You can disable "
                   "filters by setting 'filter' parameter to False")

--- a/spikesorters/tests/common_tests.py
+++ b/spikesorters/tests/common_tests.py
@@ -41,10 +41,7 @@ class SorterCommonTestSuite:
 
         params = self.SorterClass.default_params()
         
-        if self.SorterClass.compatile_with_parallel_thread:
-            parallel_cases = [False, True]
-        else:
-            parallel_cases = [False, ]
+        parallel_cases = [False, True]
         
         for parallel in parallel_cases:
             sorter = self.SorterClass(recording=recording, output_folder=None,

--- a/spikesorters/tests/common_tests.py
+++ b/spikesorters/tests/common_tests.py
@@ -31,7 +31,8 @@ class SorterCommonTestSuite:
     def test_several_groups(self):
 
         # run sorter with several groups in paralel or not
-        recording, sorting_gt = se.example_datasets.toy_example(num_channels=8, duration=30, seed=1)
+        recording, sorting_gt = se.example_datasets.toy_example(num_channels=8, duration=30, seed=1, dumpable=True,
+                                                                dump_folder='test_groups')
 
         # make 2 artificial groups
         for ch_id in range(0, 4):
@@ -55,6 +56,7 @@ class SorterCommonTestSuite:
                     for unit_id in sorting.get_unit_ids():
                         print('unit #', unit_id, 'nb', len(sorting.get_unit_spike_train(unit_id)))
                     del sorting
+
 
     def test_with_BinDatRecordingExtractor(self):
         # some sorter (TDC, KS, KS2, ...) work by default with the raw binary

--- a/spikesorters/tests/test_launcher.py
+++ b/spikesorters/tests/test_launcher.py
@@ -67,7 +67,7 @@ def test_run_sorters_multiprocessing():
 
     # multiprocessing
     t0 = time.perf_counter()
-    run_sorters(sorter_list, recording_dict, working_folder, engine='multiprocessing', engine_kargs={'processes': 4})
+    run_sorters(sorter_list, recording_dict, working_folder, engine='multiprocessing', engine_kwargs={'processes': 4})
     t1 = time.perf_counter()
     print(t1 - t0)
 
@@ -98,12 +98,12 @@ def test_run_sorters_dask():
 
     # dask
     t0 = time.perf_counter()
-    results = run_sorters(sorter_list, recording_dict, working_folder, engine='dask', engine_kargs={'client': client}, with_output=True)
+    results = run_sorters(sorter_list, recording_dict, working_folder, engine='dask',
+                          engine_kwargs={'client': client}, with_output=True)
     # dask do not return results always None
     assert results is None
     t1 = time.perf_counter()
     print(t1 - t0)
-    
 
 
 def test_collect_sorting_outputs():
@@ -112,16 +112,13 @@ def test_collect_sorting_outputs():
     print(results)
 
 
-
-
-
 if __name__ == '__main__':
-    test_run_sorters_with_list()
+    # test_run_sorters_with_list()
+    #
+    # test_run_sorters_with_dict()
 
-    #~ test_run_sorters_with_dict()
-
-    #~ test_run_sorters_multiprocessing()
+    # test_run_sorters_multiprocessing()
     
-    #~ test_run_sorters_dask()
+    test_run_sorters_dask()
 
     #~ test_collect_sorting_outputs()

--- a/spikesorters/tests/test_launcher.py
+++ b/spikesorters/tests/test_launcher.py
@@ -113,12 +113,12 @@ def test_collect_sorting_outputs():
 
 
 if __name__ == '__main__':
-    # test_run_sorters_with_list()
-    #
-    # test_run_sorters_with_dict()
+    test_run_sorters_with_list()
+
+    test_run_sorters_with_dict()
 
     # test_run_sorters_multiprocessing()
     
-    test_run_sorters_dask()
+    # test_run_sorters_dask()
 
     #~ test_collect_sorting_outputs()

--- a/spikesorters/tridesclous/tridesclous.py
+++ b/spikesorters/tridesclous/tridesclous.py
@@ -30,6 +30,7 @@ class TridesclousSorter(BaseSorter):
     sorter_name = 'tridesclous'
     installed = HAVE_TDC
     requires_locations = False
+    compatible_with_parallel = {'loky': True, 'multiprocessing': False, 'threading': False}
 
     _default_params = {
         'highpass_freq': 400.,

--- a/spikesorters/tridesclous/tridesclous.py
+++ b/spikesorters/tridesclous/tridesclous.py
@@ -10,6 +10,7 @@ import distutils.version
 
 from ..basesorter import BaseSorter
 import spikeextractors as se
+from ..sorter_tools import recover_recording
 
 try:
     import tridesclous as tdc
@@ -29,7 +30,6 @@ class TridesclousSorter(BaseSorter):
     sorter_name = 'tridesclous'
     installed = HAVE_TDC
     requires_locations = False
-    compatile_with_parallel_thread = False
 
     _default_params = {
         'highpass_freq': 400.,
@@ -98,7 +98,7 @@ class TridesclousSorter(BaseSorter):
             print(tdc_dataio)
 
     def _run(self, recording, output_folder):
-        nb_chan = recording.get_num_channels()
+        recording = recover_recording(recording)
         tdc_dataio = tdc.DataIO(dirname=str(output_folder))
 
         params = dict(self.params)

--- a/spikesorters/waveclus/waveclus.py
+++ b/spikesorters/waveclus/waveclus.py
@@ -7,7 +7,7 @@ import copy
 import spikeextractors as se
 from ..basesorter import BaseSorter
 from ..utils.shellscript import ShellScript
-
+from ..sorter_tools import recover_recording
 
 def check_if_installed(waveclus_path: Union[str, None]):
     if waveclus_path is None:
@@ -94,6 +94,7 @@ class WaveClusSorter(BaseSorter):
         se.MdaRecordingExtractor.write_recording(recording=recording, save_path=str(dataset_dir))
 
     def _run(self, recording, output_folder):
+        recording = recover_recording(recording)
         dataset_dir = output_folder / 'waveclus_dataset'
         source_dir = Path(__file__).parent
         p = self.params


### PR DESCRIPTION
@samuelgarcia I think this is a better fix for the parallel problem.

Apparently: 
- threading + joblib/multiprocessing --> :(
- joblib + joblib/multiprocessing --> :)