### PR TITLE
fixes output_folder in other disk [Windows]

### DIFF
--- a/spikesorters/hdsort/hdsort.py
+++ b/spikesorters/hdsort/hdsort.py
@@ -185,9 +185,10 @@ class HDSortSorter(BaseSorter):
 
         if "win" in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
+                        {disk_move}
                         cd {tmpdir}
                         matlab -nosplash -wait -r hdsort_master
-                    '''.format(tmpdir=output_folder)
+                    '''.format(disk_move=str(output_folder)[:2], tmpdir=output_folder)
         else:
             shell_cmd = '''
                         #!/bin/bash

--- a/spikesorters/ironclust/ironclust.py
+++ b/spikesorters/ironclust/ironclust.py
@@ -204,9 +204,10 @@ class IronClustSorter(BaseSorter):
 
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
+                {disk_move}
                 cd {tmpdir}
                 matlab -nosplash -wait -log -r run_ironclust
-            '''.format(tmpdir=tmpdir)
+            '''.format(disk_move=str(tmpdir)[:2], tmpdir=tmpdir)
         else:
             shell_cmd = '''
                 #!/bin/bash

--- a/spikesorters/kilosort/kilosort.py
+++ b/spikesorters/kilosort/kilosort.py
@@ -189,9 +189,10 @@ class KilosortSorter(BaseSorter):
         recording = recover_recording(recording)
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
+                        {disk_move}
                         cd {tmpdir}
                         matlab -nosplash -wait -log -r kilosort_master
-                    '''.format(tmpdir=output_folder)
+                    '''.format(disk_move=str(output_folder)[:2], tmpdir=output_folder)
         else:
             shell_cmd = '''
                         #!/bin/bash

--- a/spikesorters/kilosort2/kilosort2.py
+++ b/spikesorters/kilosort2/kilosort2.py
@@ -193,9 +193,10 @@ class Kilosort2Sorter(BaseSorter):
         recording = recover_recording(recording)
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
+                        {disk_move}
                         cd {tmpdir}
                         matlab -nosplash -wait -log -r kilosort2_master
-                    '''.format(tmpdir=output_folder)
+                    '''.format(disk_move=str(output_folder)[:2], tmpdir=output_folder)
         else:
             shell_cmd = '''
                         #!/bin/bash

--- a/spikesorters/kilosort2_5/kilosort2_5.py
+++ b/spikesorters/kilosort2_5/kilosort2_5.py
@@ -206,9 +206,10 @@ class Kilosort2_5Sorter(BaseSorter):
         recording = recover_recording(recording)
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
+                        {disk_move}
                         cd {tmpdir}
                         matlab -nosplash -wait -log -r kilosort2_5_master
-                    '''.format(tmpdir=output_folder)
+                    '''.format(disk_move=str(output_folder)[:2], tmpdir=output_folder)
         else:
             shell_cmd = '''
                         #!/bin/bash

--- a/spikesorters/waveclus/p_waveclus.m
+++ b/spikesorters/waveclus/p_waveclus.m
@@ -31,5 +31,5 @@ function p_waveclus(vcDir_temp, nChans, par_input)
         vcFile_cluster = fullfile(vcDir_, ['times_polytrode1', vcExt_]);
     end
     
-    movefile(vcFile_cluster,fullfile(vcDir_, 'times_results.mat'))
+    movefile(vcFile_cluster,fullfile(vcDir_, 'times_results.mat'),'f')
 end

--- a/spikesorters/waveclus/waveclus.py
+++ b/spikesorters/waveclus/waveclus.py
@@ -220,9 +220,10 @@ class WaveClusSorter(BaseSorter):
 
         if 'win' in sys.platform and sys.platform != 'darwin':
             shell_cmd = '''
+                {disk_move}
                 cd {tmpdir}
                 matlab -nosplash -wait -log -r run_waveclus
-            '''.format(tmpdir=tmpdir)
+            '''.format(disk_move=str(tmpdir)[:2], tmpdir=tmpdir)
         else:
             shell_cmd = '''
                 #!/bin/bash


### PR DESCRIPTION
Hi guys, another Windows related issue. Using the cd command doesn't work if the folder is in other disk, a line like "E:" should be added to move to that dik as well. I haven't checked but probably other sorters have this issue