### PR TITLE
Change default detect_threshold in Kilosort 2 and 2.5

### DIFF
--- a/spikesorters/kilosort2/kilosort2.py
+++ b/spikesorters/kilosort2/kilosort2.py
@@ -36,7 +36,7 @@ class Kilosort2Sorter(BaseSorter):
     requires_locations = False
 
     _default_params = {
-        'detect_threshold': 5,
+        'detect_threshold': 6,
         'projection_threshold': [10, 4],
         'preclust_threshold': 8,
         'car': True,

--- a/spikesorters/kilosort2_5/kilosort2_5.py
+++ b/spikesorters/kilosort2_5/kilosort2_5.py
@@ -36,7 +36,7 @@ class Kilosort2_5Sorter(BaseSorter):
     requires_locations = False
 
     _default_params = {
-        'detect_threshold': 5,
+        'detect_threshold': 6,
         'projection_threshold': [10, 4],
         'preclust_threshold': 8,
         'car': True,


### PR DESCRIPTION
This change brings spikesorters in line with Kilosort's defaults and published results (e.g. Steinmetz et al., 2020, bioRxiv)