### PR TITLE
Copy epochs timestamps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - libcanberra-gtk-module
 install:
 - pip install https://github.com/SpikeInterface/spikeextractors/archive/timestamps.zip
-- pip install https://github.com/SpikeInterface/spiketoolkit/archive/master.zip
+- pip install https://github.com/SpikeInterface/spiketoolkit/archive/add_return_scaled.zip
 - pip install .
 - pip install pytest==4.3
 - pip install matplotlib==3.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - packagekit-gtk3-module
     - libcanberra-gtk-module
 install:
-- pip install https://github.com/SpikeInterface/spikeextractors/archive/master.zip
+- pip install https://github.com/SpikeInterface/spikeextractors/archive/timestamps.zip
 - pip install https://github.com/SpikeInterface/spiketoolkit/archive/master.zip
 - pip install .
 - pip install pytest==4.3

--- a/spikesorters/basesorter.py
+++ b/spikesorters/basesorter.py
@@ -254,5 +254,9 @@ class BaseSorter:
                 if self.verbose:
                     print("Removing ", str(out))
                 shutil.rmtree(str(out), ignore_errors=True)
+
         sorting.set_sampling_frequency(self.recording_list[0].get_sampling_frequency())
+        sorting.copy_epochs(self.recording_list[0])
+        sorting.copy_timestamps(self.recording_list[0])
+
         return sorting


### PR DESCRIPTION
This PR makes the `BaseSorter` copy timestamps and epochs to the output `SortingExtractor`

Requires: https://github.com/SpikeInterface/spikeextractors/pull/586 and https://github.com/SpikeInterface/spiketoolkit/pull/440